### PR TITLE
Allow update time out and memory size in each function

### DIFF
--- a/src/main/java/com/github/seanroy/plugins/DeployLambdaMojo.java
+++ b/src/main/java/com/github/seanroy/plugins/DeployLambdaMojo.java
@@ -119,8 +119,8 @@ public class DeployLambdaMojo extends AbstractLambdaMojo {
                 .withDescription(lambdaFunction.getDescription())
                 .withHandler(lambdaFunction.getHandler())
                 .withRole(lambdaRoleArn)
-                .withTimeout(ofNullable(lambdaFunction.getTimeout()).orElse(timeout))
-                .withMemorySize(ofNullable(lambdaFunction.getMemorySize()).orElse(memorySize))
+                .withTimeout(lambdaFunction.getTimeout())
+                .withMemorySize(lambdaFunction.getMemorySize())
                 .withRuntime(runtime)
                 .withVpcConfig(getVpcConfig(lambdaFunction));
         lambdaClient.updateFunctionConfiguration(updateFunctionRequest);

--- a/src/main/java/com/github/seanroy/plugins/DeployLambdaMojo.java
+++ b/src/main/java/com/github/seanroy/plugins/DeployLambdaMojo.java
@@ -119,8 +119,8 @@ public class DeployLambdaMojo extends AbstractLambdaMojo {
                 .withDescription(lambdaFunction.getDescription())
                 .withHandler(lambdaFunction.getHandler())
                 .withRole(lambdaRoleArn)
-                .withTimeout(timeout)
-                .withMemorySize(memorySize)
+                .withTimeout(ofNullable(lambdaFunction.getTimeout()).orElse(timeout))
+                .withMemorySize(ofNullable(lambdaFunction.getMemorySize()).orElse(memorySize))
                 .withRuntime(runtime)
                 .withVpcConfig(getVpcConfig(lambdaFunction));
         lambdaClient.updateFunctionConfiguration(updateFunctionRequest);


### PR DESCRIPTION
Hi SeanRoy,

I found this project when I trying to write a simple python script to upload multi function in same project to AWS lambda. Now, it's not necessary anymore. Thanks you.

However, when I upload my function to AWS, I already set memory size of my function is 256MB
`<lambdaFunctionsJSON>
                        [
                            {
                                "functionName": "GetToken",
                                "description": "Get token from refresh token",
                                "handler": "com.woodenextreme.webservice.GetTokenHandler",
                                "timeout": 60,
                                "memorySize": 256
                            },
                            {
                                "functionName": "GetIAP",
                                "description": "Get IAP of current user",
                                "handler": "com.woodenextreme.webservice.GetIAPHandler",
                                "timeout": 60,
                                "memorySize": 256
                            }
                        ]
                    </lambdaFunctionsJSON>`
However, when I check in AWS console, I found this value have been changed to 1024MB. 
I check in your code and I think, maybe you forgot to check if user already set time out & memory or not.

Hope to heard from you soon,

Mạnh Tú