### PR TITLE
Sonatype artifact maven-version-plugin error in root pom.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@
             </plugin>
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
-                <artifactId>maven-versions-plugin</artifactId>
+                <artifactId>maven-version-plugin</artifactId>
                 <version>1.0</version>
             </plugin>
             <plugin>


### PR DESCRIPTION
Root pom had "maven-versions-plugin", should be "version". Fixed.