### PR TITLE
Updates to allow for just updating function code

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ All of the AWS Lambda configuration parameters may be set within the lambda plug
 * `version` REQUIRED version of the deliverable. Note that this is the version you assign to your function, not the one assigned by AWS when publish=true.
 * `alias` OPTIONAL, but requires publish=true.  Assigns an alias to the AWS version of this function.  Useful for maintaining versions intended for different environments on the same function.  For instance, development, qa, production, etc.
 * `s3Bucket` REQUIRED Defaults to lambda-function-code. The AWS S3 bucket to which to upload your code from which it will be deployed to Lambda.
-* `region` Defaults to eu-west-1 The AWS region to use for your function.
+* `region` Defaults to us-east-1 The AWS region to use for your function.
 * `runtime` Defaults to Java8 Specifies whether this is Java8, NodeJs and Python.
 * `lambdaRoleArn` REQUIRED The ARN of the AWS role which the lambda user will assume when it executes. Note that the role must be assumable by Lambda and must have Cloudwatch Logs permissions and AWSLambdaDynamoDBExecutionRole policy.
 * `lambdaFunctions` Lamda functions that can be configured using tags in pom.xml.

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     </contributors>
 
     <properties>
-        <aws.version>1.11.202</aws.version>
+        <aws.version>1.11.271</aws.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/src/main/java/com/github/seanroy/plugins/AbstractLambdaMojo.java
+++ b/src/main/java/com/github/seanroy/plugins/AbstractLambdaMojo.java
@@ -10,12 +10,10 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -125,7 +123,7 @@ public abstract class AbstractLambdaMojo extends AbstractMojo {
     /**
      * <p>The Amazon Resource Name (ARN) of the IAM role that Lambda will assume when it executes your function.</p>
      */
-    @Parameter(property = "lambdaRoleArn", defaultValue = "${lambdaRoleArn}", required = true)
+    @Parameter(property = "lambdaRoleArn", defaultValue = "${lambdaRoleArn}")
     public String lambdaRoleArn;
     /**
      * <p>The JSON confuguration for Lambda functions. @see {@link LambdaFunction}.</p>
@@ -295,6 +293,7 @@ public abstract class AbstractLambdaMojo extends AbstractMojo {
                           .withSecurityGroupsIds(ofNullable(vpcSecurityGroupIds).orElse(new ArrayList<>()))
                           .withVersion(version)
                           .withPublish(ofNullable(lambdaFunction.isPublish()).orElse(publish))
+                          .withLambdaRoleArn(ofNullable(lambdaFunction.getLambdaRoleArn()).orElse(lambdaRoleArn))
                           .withAliases(aliases(lambdaFunction.isPublish()))
                           .withTriggers(ofNullable(lambdaFunction.getTriggers()).map(triggers -> triggers.stream()
                                                                                                          .map(trigger -> {

--- a/src/main/java/com/github/seanroy/plugins/DeployLambdaMojo.java
+++ b/src/main/java/com/github/seanroy/plugins/DeployLambdaMojo.java
@@ -6,8 +6,6 @@ import static java.util.Optional.of;
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toList;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -18,7 +16,6 @@ import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 
@@ -64,14 +61,9 @@ import com.amazonaws.services.lambda.model.ResourceNotFoundException;
 import com.amazonaws.services.lambda.model.UpdateAliasRequest;
 import com.amazonaws.services.lambda.model.UpdateEventSourceMappingRequest;
 import com.amazonaws.services.lambda.model.UpdateEventSourceMappingResult;
-import com.amazonaws.services.lambda.model.UpdateFunctionCodeRequest;
-import com.amazonaws.services.lambda.model.UpdateFunctionCodeResult;
 import com.amazonaws.services.lambda.model.UpdateFunctionConfigurationRequest;
 import com.amazonaws.services.lambda.model.VpcConfig;
 import com.amazonaws.services.lambda.model.VpcConfigResponse;
-import com.amazonaws.services.s3.model.AmazonS3Exception;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.PutObjectResult;
 import com.amazonaws.services.sns.model.CreateTopicRequest;
 import com.amazonaws.services.sns.model.CreateTopicResult;
 import com.amazonaws.services.sns.model.ListSubscriptionsResult;
@@ -132,19 +124,6 @@ public class DeployLambdaMojo extends AbstractLambdaMojo {
         } 
         
         return lambdaFunction;
-    };
-
-    private Function<LambdaFunction, LambdaFunction> updateFunctionCode = (LambdaFunction lambdaFunction) -> {
-        getLog().info("About to update functionCode for " + lambdaFunction.getFunctionName());
-        UpdateFunctionCodeRequest updateFunctionRequest = new UpdateFunctionCodeRequest()
-                .withFunctionName(lambdaFunction.getFunctionName())
-                .withS3Bucket(s3Bucket)
-                .withS3Key(fileName)
-                .withPublish(lambdaFunction.isPublish());
-        UpdateFunctionCodeResult updateFunctionCodeResult = lambdaClient.updateFunctionCode(updateFunctionRequest);
-        return lambdaFunction
-                .withVersion(updateFunctionCodeResult.getVersion())
-                .withFunctionArn(updateFunctionCodeResult.getFunctionArn());
     };
 
     private Function<LambdaFunction, LambdaFunction> updateFunctionConfig = (LambdaFunction lambdaFunction) -> {
@@ -507,33 +486,6 @@ public class DeployLambdaMojo extends AbstractLambdaMojo {
                 .withSubnetIds(lambdaFunction.getSubnetIds());
     }
 
-    private void uploadJarToS3() throws Exception {
-        String bucket = getBucket();
-        File file = new File(functionCode);
-        String localmd5 = DigestUtils.md5Hex(new FileInputStream(file));
-        getLog().debug(String.format("Local file's MD5 hash is %s.", localmd5));
-
-        ofNullable(getObjectMetadata(bucket))
-                .map(ObjectMetadata::getETag)
-                .map(remoteMD5 -> {
-                    getLog().info(fileName + " exists in S3 with MD5 hash " + remoteMD5);
-                    // This comparison will no longer work if we ever go to multipart uploads.  Etags are not
-                    // computed as MD5 sums for multipart uploads in s3.
-                    return localmd5.equals(remoteMD5);
-                })
-                .map(isTheSame -> {
-                    if (isTheSame) {
-                        getLog().info(fileName + " is up to date in AWS S3 bucket " + s3Bucket + ". Not uploading...");
-                        return true;
-                    }
-                    return null; // file should be imported
-                })
-                .orElseGet(() -> {
-                    upload(file);
-                    return true;
-                });
-    }
-    
     /**
      * Remove orphaned kinesis stream triggers.
      * TODO: Combine with cleanUpOrphanedDynamoDBTriggers.
@@ -810,26 +762,4 @@ public class DeployLambdaMojo extends AbstractLambdaMojo {
                       
       return lambdaFunction;
     };
-
-    private PutObjectResult upload(File file) {
-        getLog().info("Uploading " + functionCode + " to AWS S3 bucket " + s3Bucket);
-        PutObjectResult putObjectResult = s3Client.putObject(s3Bucket, fileName, file);
-        getLog().info("Upload complete...");
-        return putObjectResult;
-    }
-
-    private ObjectMetadata getObjectMetadata(String bucket) {
-        try {
-            return s3Client.getObjectMetadata(bucket, fileName);
-        } catch (AmazonS3Exception ignored) {
-            return null;
-        }
-    }
-
-    private String getBucket() {
-        if (s3Client.listBuckets().stream().noneMatch(p -> Objects.equals(p.getName(), s3Bucket))) {
-            getLog().info("Created bucket s3://" + s3Client.createBucket(s3Bucket).getName());
-        }
-        return s3Bucket;
-    }
 }

--- a/src/main/java/com/github/seanroy/plugins/DeployLambdaMojo.java
+++ b/src/main/java/com/github/seanroy/plugins/DeployLambdaMojo.java
@@ -153,7 +153,7 @@ public class DeployLambdaMojo extends AbstractLambdaMojo {
                 .withFunctionName(lambdaFunction.getFunctionName())
                 .withDescription(lambdaFunction.getDescription())
                 .withHandler(lambdaFunction.getHandler())
-                .withRole(lambdaRoleArn)
+                .withRole(lambdaFunction.getLambdaRoleArn())
                 .withTimeout(lambdaFunction.getTimeout())
                 .withMemorySize(lambdaFunction.getMemorySize())
                 .withRuntime(runtime)
@@ -426,7 +426,7 @@ public class DeployLambdaMojo extends AbstractLambdaMojo {
                     }
                     boolean isDescriptionChanged = isChangeStr.test(config.getDescription(), lambdaFunction.getDescription());
                     boolean isHandlerChanged = isChangeStr.test(config.getHandler(), lambdaFunction.getHandler());
-                    boolean isRoleChanged = isChangeStr.test(config.getRole(), lambdaRoleArn);
+                    boolean isRoleChanged = isChangeStr.test(config.getRole(), lambdaFunction.getLambdaRoleArn());
                     boolean isTimeoutChanged = isChangeInt.test(config.getTimeout(), lambdaFunction.getTimeout());
                     boolean isMemoryChanged = isChangeInt.test(config.getMemorySize(), lambdaFunction.getMemorySize());
                     boolean isSecurityGroupIdsChanged = isChangeList.test(vpcConfig.getSecurityGroupIds(), lambdaFunction.getSecurityGroupIds());
@@ -480,7 +480,7 @@ public class DeployLambdaMojo extends AbstractLambdaMojo {
         getLog().info("About to create function " + lambdaFunction.getFunctionName());
         CreateFunctionRequest createFunctionRequest = new CreateFunctionRequest()
                 .withDescription(lambdaFunction.getDescription())
-                .withRole(lambdaRoleArn)
+                .withRole(lambdaFunction.getLambdaRoleArn())
                 .withFunctionName(lambdaFunction.getFunctionName())
                 .withHandler(lambdaFunction.getHandler())
                 .withRuntime(runtime)

--- a/src/main/java/com/github/seanroy/plugins/LambdaFunction.java
+++ b/src/main/java/com/github/seanroy/plugins/LambdaFunction.java
@@ -74,6 +74,12 @@ public class LambdaFunction {
      */
     private Boolean publish;
     /**
+     * <p>
+     * The Amazon Resource Name (ARN) of the IAM role that Lambda will assume when it executes your function.
+     * </p>
+     */
+    private String lambdaRoleArn;
+    /**
      * <p>The Amazon Resource Name (ARN) assigned to the function</p>
      */
     private String functionArn;
@@ -186,6 +192,10 @@ public class LambdaFunction {
         this.publish = publish;
     }
 
+    public String getLambdaRoleArn() { return lambdaRoleArn; }
+
+    public void setLambdaRoleArn(String lambdaRoleArn) { this.lambdaRoleArn = lambdaRoleArn; }
+
     public String getFunctionArn() {
         return functionArn;
     }
@@ -278,6 +288,11 @@ public class LambdaFunction {
         return this;
     }
 
+    public LambdaFunction withLambdaRoleArn(String lambdaRoleArn) {
+        this.lambdaRoleArn = lambdaRoleArn;
+        return this;
+    }
+
     public LambdaFunction withFunctionArn(String functionArn) {
         this.functionArn = functionArn;
         return this;
@@ -330,6 +345,7 @@ public class LambdaFunction {
                 .append(", subnetIds=").append(subnetIds)
                 .append(", aliases=").append(aliases)
                 .append(", publish=").append(publish)
+                .append(", lambdaRoleArn=").append(lambdaRoleArn)
                 .append(", triggers=").append(triggers)
                 .append(", keepAlive=").append(keepAlive)
                 .append(", environmentVariables=").append(environmentVariables)

--- a/src/main/java/com/github/seanroy/plugins/UpdateLambdaCodeMojo.java
+++ b/src/main/java/com/github/seanroy/plugins/UpdateLambdaCodeMojo.java
@@ -1,0 +1,28 @@
+package com.github.seanroy.plugins;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+
+/**
+ * I am a update code mojo responsible to update lambda function code in AWS.
+ *
+ * @author Joseph Wortmann, <a href="mailto:joseph.wortmann@gmail.com">Joseph Wortmann</a> 2/1/2018.
+ */
+@Mojo(name = "update-lambda-code")
+public class UpdateLambdaCodeMojo extends AbstractLambdaMojo {
+
+    @Override
+    public void execute() throws MojoExecutionException {
+        super.execute();
+        try {
+            uploadJarToS3();
+            lambdaFunctions.stream().map(f -> {
+                getLog().info("---- Update function code " + f.getFunctionName() + " -----");
+                return f;
+            }).forEach(lf -> updateFunctionCode.apply(lf));
+        } catch (Exception e) {
+            getLog().error("Error during processing", e);
+            throw new MojoExecutionException(e.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/github/seanroy/plugins/LambdaTest.java
+++ b/src/test/java/com/github/seanroy/plugins/LambdaTest.java
@@ -65,6 +65,10 @@ public class LambdaTest extends AbstractMojoTestCase {
         DeployLambdaMojo lambduhMojo = (DeployLambdaMojo) lookupMojo( "deploy-lambda", pom );
         assertNotNull( lambduhMojo );
         lambduhMojo.execute();
+
+        UpdateLambdaCodeMojo updateMojo = (UpdateLambdaCodeMojo) lookupMojo( "update-lambda-code", pom);
+        assertNotNull( updateMojo );
+        updateMojo.execute();
    
         DeleteLambdaMojo deleteMojo = (DeleteLambdaMojo) lookupMojo( "delete-lambda", pom);
         assertNotNull( deleteMojo );

--- a/src/test/resources/lambda-configuration-test.json
+++ b/src/test/resources/lambda-configuration-test.json
@@ -3,6 +3,7 @@
     "functionName": "flowlab-example-lambda",
     "description": "Receives input and logs it",
     "handler": "no.flowlab.ExampleLambda",
+    "lambdaRoleArn": "arn:aws:iam::280237693431:role/lambda_basic_execution",
     "triggers": [
       {
         "integration": "SNS",


### PR DESCRIPTION
There are many use cases where all one wants to do on a build is update the code of an exiting Lambda function. This is normally because the rest of the configuration is managed elsewhere (e.g. - CloudFormation, Terraform, by my fat fingers...).

- Updated the pom to latest AWS libs
- Corrected the README re: the default region
- Moved the lambdaRoleArn to inside LambdaFunction. This both supports the new Mojo and is more appropriate from a managing security perspective. Still supports declaring it "globally".
- Added a new mojo (UpdateLambdaCodeMojo) to support simple code updates. Moved supporting code from DeployLambdaMojo to AbstractLambdaMojo.