### PR TITLE
Added additional resources that the plugin needs access to

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,9 +193,16 @@ IAM permissions required by this plugin:
 * action `lambda:UpdateFunctionCode`
 * action `lambda:UpdateFunctionConfiguration`
 * action `lambda:ListAliases`
+* action `lambda:GetPolicy` on resource: `arn:aws:lambda:<region>:<acount-number>:function:<function-name>`
+* action `lambda:UpdateAlias` on resource: `arn:aws:lambda:<region>:<acount-number>:function:<function-name>`
+* action `lambda:ListEventSourceMappings` on resource: *
 * action `events:PutRule` on  resource `arn:aws:events:<region>:<acount-number>:rule/*`
 * action `events:PutTargets` on  resource `arn:aws:events:<region>:<acount-number>:rule/*`
+* action `events:ListRuleNamesByTarget` on  resource `arn:aws:events:<region>:<acount-number>:rule/*`
+* action `events:DescribeRule` on  resource `arn:aws:events:<region>:<acount-number>:rule/KEEP-ALIVE-<function-name>`
 * action `kinesis:GetRecords, GetShardIterator, DescribeStream, and ListStreams on Kinesis streams`
+* action `iam:PassRole` on  resource `<lambdaRoleArn>`
+* action `SNS:ListSubscriptions` on  resource `arn:aws:events:<region>:<acount-number>:*`
 
 ### Developers
 If you are interested in contributing to this project, please note that current development can be found in the SNAPSHOT branch of the coming release.  When making pull requests, please create them against this branch.


### PR DESCRIPTION
Six months ago when I did deployments, this used to work fine. When I started doing deployments today, it failed for several new resources. I have added all resources that AWS asked me to give access to