### PR TITLE
Ability to set Skill Id for Alexa Skills Kit trigger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,6 +229,9 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <source>8</source>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/github/seanroy/plugins/DeployLambdaMojo.java
+++ b/src/main/java/com/github/seanroy/plugins/DeployLambdaMojo.java
@@ -227,7 +227,8 @@ public class DeployLambdaMojo extends AbstractLambdaMojo {
                     .withPrincipal(PRINCIPAL_ALEXA)
                     .withFunctionName(lambdaFunction.getFunctionName())
                     .withQualifier(lambdaFunction.getQualifier())
-                    .withStatementId(getAlexaPermissionStatementId());
+                    .withStatementId(getAlexaPermissionStatementId())
+                    .withEventSourceToken(trigger.getAlexaSkillId());
     
             AddPermissionResult addPermissionResult = lambdaClient.addPermission(addPermissionRequest);
         }

--- a/src/main/java/com/github/seanroy/plugins/Trigger.java
+++ b/src/main/java/com/github/seanroy/plugins/Trigger.java
@@ -38,6 +38,9 @@ public class Trigger {
     // created as part of Dynamo DB Table
     private String standardQueue;
 
+    // Support for Alexa Skills Kit
+    private String alexaSkillId;
+
     // After create Trigger gets own arn
     private String triggerArn;
 
@@ -151,7 +154,15 @@ public class Trigger {
 		this.standardQueue = standardQueue;
 	}
 
-	public Trigger withIntegration(String integration) {
+    public String getAlexaSkillId() {
+        return alexaSkillId;
+    }
+
+    public void setAlexaSkillId(String alexaSkillId) {
+        this.alexaSkillId = alexaSkillId;
+    }
+
+    public Trigger withIntegration(String integration) {
         this.integration = integration;
         return this;
     }
@@ -206,6 +217,11 @@ public class Trigger {
         return this;
     }
 
+    public Trigger withAlexaSkillId(String alexaSkillId) {
+        this.alexaSkillId = alexaSkillId;
+        return this;
+    }
+
     @Override
     public String toString() {
         return new StringBuilder("Trigger{")
@@ -221,6 +237,7 @@ public class Trigger {
                 .append(", triggerArn='").append(triggerArn).append('\'')
                 .append(", lextBotName='").append(lexBotName).append('\'')
                 .append(", standardQueue='").append(standardQueue).append('\'')
+                .append(", alexaSkillId='").append(alexaSkillId).append('\'')
                 .append(", enabled=").append(enabled)
                 .append('}').toString();
     }


### PR DESCRIPTION
As a best practice, it's recommended to add trigger with Skill ID verification enabled.

an example trigger in lambdaFunctionsJSON:
```
"triggers": [ 
  {
    "integration": "Alexa Skills Kit",
    "alexaSkillId": "amzn1.ask.skill........"
  }
]
```