### PR TITLE
Add skip configuration parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Current configuration of LambdaFunction can be found in LambdaFunction.java.
                     <artifactId>lambda-maven-plugin</artifactId>
                     <version>2.3.2</version>
                     <configuration>
+                        <skip>false</skip>
                         <functionCode>${lambda.functionCode}</functionCode>
                         <version>${lambda.version}</version>
                         <alias>development</alias>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
             <version>3.3.3</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-testing</groupId>
@@ -80,6 +81,7 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-compat</artifactId>
             <version>3.3.3</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -209,6 +211,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -221,6 +224,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.3.2</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/src/main/java/com/github/seanroy/plugins/AbstractLambdaMojo.java
+++ b/src/main/java/com/github/seanroy/plugins/AbstractLambdaMojo.java
@@ -79,7 +79,10 @@ public abstract class AbstractLambdaMojo extends AbstractMojo {
     public static final String PRINCIPAL_SNS    = "sns.amazonaws.com";
     public static final String PRINCIPAL_EVENTS = "events.amazonaws.com"; // Cloudwatch events
     public static final String PRINCIPAL_SQS    = "sqs.amazonaws.com";
-    
+
+    @Parameter(property = "skip", defaultValue = "false")
+    public boolean skip;
+
     /**
      * <p>The AWS access key.</p>
      */
@@ -243,6 +246,13 @@ public abstract class AbstractLambdaMojo extends AbstractMojo {
     public AmazonKinesis kinesisClient;
     public AmazonCloudWatchEvents cloudWatchEventsClient;
     public AmazonSQS sqsClient;
+
+    protected boolean checkSkip() {
+        if(skip) {
+            getLog().info("Execution skipped.");
+        }
+        return skip;
+    }
 
     @Override
     public void execute() throws MojoExecutionException {

--- a/src/main/java/com/github/seanroy/plugins/DeleteLambdaMojo.java
+++ b/src/main/java/com/github/seanroy/plugins/DeleteLambdaMojo.java
@@ -1,8 +1,6 @@
 package com.github.seanroy.plugins;
 
 
-import static java.util.Optional.ofNullable;
-
 import java.util.List;
 import java.util.function.Function;
 
@@ -30,6 +28,7 @@ public class DeleteLambdaMojo extends AbstractLambdaMojo {
      * The entry point into the AWS lambda function.
      */
     public void execute() throws MojoExecutionException {
+        if(checkSkip()) return;
         super.execute();
         try {
             lambdaFunctions.forEach(context -> {

--- a/src/main/java/com/github/seanroy/plugins/DeployLambdaMojo.java
+++ b/src/main/java/com/github/seanroy/plugins/DeployLambdaMojo.java
@@ -88,6 +88,7 @@ public class DeployLambdaMojo extends AbstractLambdaMojo {
 
     @Override
     public void execute() throws MojoExecutionException {
+        if(checkSkip()) return;
         super.execute();
         try {
             uploadJarToS3();

--- a/src/main/java/com/github/seanroy/plugins/UpdateLambdaCodeMojo.java
+++ b/src/main/java/com/github/seanroy/plugins/UpdateLambdaCodeMojo.java
@@ -17,6 +17,7 @@ public class UpdateLambdaCodeMojo extends AbstractLambdaMojo {
 
     @Override
     public void execute() throws MojoExecutionException {
+        if(checkSkip()) return;
         super.execute();
         try {
             uploadJarToS3();

--- a/src/test/resources/test-projects/basic-test/basic-pom.xml
+++ b/src/test/resources/test-projects/basic-test/basic-pom.xml
@@ -28,6 +28,7 @@
       <plugin>
         <artifactId>lambda-maven-plugin</artifactId>
         <configuration>
+          <skip>false</skip>
           <functionCode>src/test/resources/test-projects/basic-test/lambda-test-0.0.1-SNAPSHOT.jar</functionCode>
           <version>0.1.1-Test</version>
           <memorySize>512</memorySize>


### PR DESCRIPTION
This parameter makes multi-module builds much easier, and is used by multiple original apache maven plugins.
I also fixed some small build issues which created a warning when running the build.