### PR TITLE
Add generateDefaultAlias flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Current configuration of LambdaFunction can be found in LambdaFunction.java.
                         <functionCode>${lambda.functionCode}</functionCode>
                         <version>${lambda.version}</version>
                         <alias>development</alias>
+                        <generateDefaultAlias>true</generateDefaultAlias>
                         <vpcSecurityGroupIds>sg-123456</vpcSecurityGroupIds>
                         <vpcSubnetIds>subnet-123456,subnet-123456,subnet-123456</vpcSubnetIds>
                         <lambdaRoleArn>arn:aws:iam::1234567:role/YourLambdaS3Role</lambdaRoleArn>

--- a/src/main/java/com/github/seanroy/plugins/AbstractLambdaMojo.java
+++ b/src/main/java/com/github/seanroy/plugins/AbstractLambdaMojo.java
@@ -106,6 +106,15 @@ public abstract class AbstractLambdaMojo extends AbstractMojo {
     
     @Parameter(property = "alias")
     public String alias;
+
+    /**
+     * <p>
+     *     If both publish and generateDefaultAlias is true, an alias with the same name as the function's version will be created.
+     *     The default value is true.
+     * </p>
+     */
+    @Parameter(property = "generateDefaultAlias", defaultValue = "true")
+    public boolean generateDefaultAlias;
     
     /**
      * <p>Amazon region. Default value is us-east-1.</p>
@@ -515,7 +524,14 @@ public abstract class AbstractLambdaMojo extends AbstractMojo {
 
     private List<String> aliases(boolean publish) {
         if (publish) {
-            return new ArrayList<String>() {{ add(version); ofNullable(alias).ifPresent(a -> add(a)); }};
+            List<String> aliases = new ArrayList<>();
+            if(generateDefaultAlias) {
+                aliases.add(version);
+            }
+            if(alias != null) {
+                aliases.add(alias);
+            }
+            return aliases;
         }
         return emptyList();
     }


### PR DESCRIPTION
AWS Lambda hase a sum code size limit of 75GB.
Every new version of a lambda function goes towards this limit.
There are multiple cleanup scripts on the internet that can be used to clean old versions of lambda functions, none of which can delete a version when there are aliases set for it.
Aliases should generally only be used when we want to preserve a specific version for whatever reason.

This flag makes it possible to NOT generate an alias while uploading, unless one is explicitly set with the <alias> tag.
The default functionality is unchanged, so it's backwards compatible, it only has effect when configured.